### PR TITLE
fix(transit-ingest): extract poll loop from runRealtime to caller

### DIFF
--- a/transit-ingest/src/pipeline/gtfs-realtime.ts
+++ b/transit-ingest/src/pipeline/gtfs-realtime.ts
@@ -26,95 +26,68 @@ const safeFetchProtobuf = fromAsyncThrowable(fetchProtobuf, (e: unknown) => e as
 export async function runRealtime(
     ctx: Context,
     urls: string[],
-    pollInterval: number,
+    lastHashes: Map<string, string>,
+    lastCachedHeaders: Map<string, CachedHeaders>,
 ): Promise<Result<RealtimeSummary, IngestError>> {
-    const lastHashes = new Map<string, string>();
-    const lastCachedHeaders = new Map<string, CachedHeaders>();
+    for (const url of urls) {
+        const fetchResult = await safeFetchProtobuf(
+            url,
+            ctx.controller.signal,
+            lastHashes.get(url),
+            lastCachedHeaders.get(url),
+        );
 
-    while (!ctx.controller.signal.aborted) {
-        const loopStart = Date.now();
-
-        for (const url of urls) {
-            const fetchResult = await safeFetchProtobuf(
-                url,
-                ctx.controller.signal,
-                lastHashes.get(url),
-                lastCachedHeaders.get(url),
+        if (fetchResult.isErr()) {
+            ctx.errors.push(fetchResult.error);
+            ctx.skipped++;
+            ctx.logger.error(
+                { url, err: fetchResult.error },
+                "Feed fetch failed, continuing to next",
             );
-
-            if (fetchResult.isErr()) {
-                ctx.errors.push(fetchResult.error);
-                ctx.skipped++;
-                ctx.logger.error(
-                    { url, err: fetchResult.error },
-                    "Feed fetch failed, continuing to next",
-                );
-                continue;
-            }
-
-            const result = fetchResult.value;
-
-            if (!result.changed) {
-                ctx.logger.debug({ url }, "Feed unchanged (304 or hash match), skipping");
-                continue;
-            }
-
-            const { data } = result;
-
-            const prevHash = lastHashes.get(url);
-
-            if (prevHash === data.hash) {
-                ctx.logger.debug({ url, hash: data.hash }, "Feed unchanged, skipping");
-                continue;
-            }
-
-            ctx.logger.debug(
-                { url, bytes: data.bytes.length, hash: data.hash },
-                "Processing realtime feed",
-            );
-
-            const pipelineResult = await runPipelines(ctx, data, url);
-
-            if (pipelineResult.isErr()) {
-                ctx.errors.push(pipelineResult.error);
-                ctx.skipped++;
-                ctx.logger.error(
-                    { url, err: pipelineResult.error },
-                    "Feed failed, continuing to next",
-                );
-                continue;
-            }
-
-            // Only record hash after successful pipeline run - failed feeds should be retried
-            lastHashes.set(url, data.hash);
-            lastCachedHeaders.set(url, result.cachedHeaders);
-
-            ctx.logger.debug(
-                { url, errors: ctx.errors.length, skipped: ctx.skipped },
-                "Feed processed",
-            );
+            continue;
         }
 
-        if (pollInterval <= 0) break;
+        const result = fetchResult.value;
 
-        const loopElapse = Date.now() - loopStart;
-        const sleepDuration = pollInterval * 1000 - loopElapse;
-        ctx.logger.debug({ loopElapse }, "Realtime loop finished");
+        if (!result.changed) {
+            ctx.logger.debug({ url }, "Feed unchanged (304 or hash match), skipping");
+            continue;
+        }
 
-        ctx.logger.debug({ pollInterval, sleepDuration }, "Waiting for next poll");
-        await new Promise<void>((resolve) => {
-            let cleaned = false;
-            const cleanup = () => {
-                if (cleaned) return;
-                cleaned = true;
-                clearTimeout(timer);
-                ctx.controller.signal.removeEventListener("abort", onAbort);
-                resolve();
-            };
-            const timer = setTimeout(cleanup, sleepDuration);
-            const onAbort = () => cleanup();
-            ctx.controller.signal.addEventListener("abort", onAbort, { once: true });
-        });
+        const { data } = result;
+
+        const prevHash = lastHashes.get(url);
+
+        if (prevHash === data.hash) {
+            ctx.logger.debug({ url, hash: data.hash }, "Feed unchanged, skipping");
+            continue;
+        }
+
+        ctx.logger.debug(
+            { url, bytes: data.bytes.length, hash: data.hash },
+            "Processing realtime feed",
+        );
+
+        const pipelineResult = await runPipelines(ctx, data, url);
+
+        if (pipelineResult.isErr()) {
+            ctx.errors.push(pipelineResult.error);
+            ctx.skipped++;
+            ctx.logger.error(
+                { url, err: pipelineResult.error },
+                "Feed failed, continuing to next",
+            );
+            continue;
+        }
+
+        // Only record hash after successful pipeline run - failed feeds should be retried
+        lastHashes.set(url, data.hash);
+        lastCachedHeaders.set(url, result.cachedHeaders);
+
+        ctx.logger.debug(
+            { url, errors: ctx.errors.length, skipped: ctx.skipped },
+            "Feed processed",
+        );
     }
 
     return ok({ errors: ctx.errors, skipped: ctx.skipped });

--- a/transit-ingest/src/pipeline/run.ts
+++ b/transit-ingest/src/pipeline/run.ts
@@ -5,6 +5,7 @@ import { createContext } from "./core/context";
 import type { IngestError } from "./core/error";
 import { runStatic } from "./gtfs-static";
 import { runRealtime } from "./gtfs-realtime";
+import type { CachedHeaders } from "./source/protobuf-source";
 import { runRealizeInstances } from "./realize-instances";
 
 export function resolveDb(databaseUrl?: string): Db {
@@ -57,6 +58,21 @@ export async function runStaticPipeline(
     });
 }
 
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        const timer = setTimeout(() => {
+            signal.removeEventListener("abort", onAbort);
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(timer);
+            resolve();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+    });
+}
+
 export async function runRealtimePipeline(
     db: Db,
     agencyId: string,
@@ -65,19 +81,34 @@ export async function runRealtimePipeline(
     verbose: boolean,
     pretty: boolean,
 ): Promise<void> {
-    const ctx = createContext(db, { agencyId, verbose, pretty });
-    const onSigint = () => ctx.controller.abort();
+    const controller = new AbortController();
+    const onSigint = () => controller.abort();
     process.on("SIGINT", onSigint);
 
-    ctx.logger.info({ agencyId, urls, poll: pollInterval }, "Realtime config");
+    let lastHashes = new Map<string, string>();
+    let lastCachedHeaders = new Map<string, CachedHeaders>();
 
     try {
-        const result = await runRealtime(ctx, urls, pollInterval);
-        logSummary(result, ctx.logger, {
-            ok: "Realtime data processed successfully.",
-            warn: "Realtime data processed with recoverable errors",
-            err: "Realtime processing failed",
-        });
+        while (!controller.signal.aborted) {
+            const loopStart = Date.now();
+            const ctx = createContext(db, { agencyId, verbose, pretty });
+
+            const result = await runRealtime(ctx, urls, lastHashes, lastCachedHeaders);
+
+            logSummary(result, ctx.logger, {
+                ok: "Realtime data processed successfully.",
+                warn: "Realtime data processed with recoverable errors",
+                err: "Realtime processing failed",
+            });
+
+            if (pollInterval <= 0) break;
+
+            const elapsed = Date.now() - loopStart;
+            const sleepDuration = pollInterval * 1000 - elapsed;
+            if (sleepDuration > 0) {
+                await sleep(sleepDuration, controller.signal);
+            }
+        }
     } finally {
         process.removeListener("SIGINT", onSigint);
     }


### PR DESCRIPTION
ctx.errors grew unbounded across poll iterations, causing OOM on longruns. runRealtime now does a single URL pass per call; runRealtimePipeline owns the while loop and creates a fresh ctx each iteration, bounding error array lifetime to one cycle. Extracted abort-aware sleep helper.